### PR TITLE
게시글 create, update, delete 구현

### DIFF
--- a/src/main/java/org/example/workingmoney/domain/entity/Post.java
+++ b/src/main/java/org/example/workingmoney/domain/entity/Post.java
@@ -1,0 +1,31 @@
+package org.example.workingmoney.domain.entity;
+
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Post {
+
+    @Nonnull
+    private final Long id;
+
+    @Nonnull
+    private final String userId;
+
+    @Nonnull
+    private final String categoryCode;
+
+    @Nonnull
+    private final String title;
+
+    @Nonnull
+    private final String content;
+
+    @Nonnull
+    private final Long likeCount;
+}
+
+
+

--- a/src/main/java/org/example/workingmoney/domain/entity/PostCategory.java
+++ b/src/main/java/org/example/workingmoney/domain/entity/PostCategory.java
@@ -1,0 +1,33 @@
+package org.example.workingmoney.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum PostCategory {
+    KOREAN_STOCKS("korean_stocks"),
+    AMERICAN_STOCKS("american_stocks"),
+    CRYPTO_CURRENCY("crypto_currency");
+
+    private final String code;
+
+    PostCategory(String code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public String getCode() {
+        return code;
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static PostCategory from(String value) {
+        return Arrays.stream(values())
+                .filter(c -> c.code.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid category: " + value));
+    }
+}
+
+

--- a/src/main/java/org/example/workingmoney/repository/post/PostEntity.java
+++ b/src/main/java/org/example/workingmoney/repository/post/PostEntity.java
@@ -1,0 +1,30 @@
+package org.example.workingmoney.repository.post;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.example.workingmoney.domain.entity.Post;
+import org.example.workingmoney.repository.common.TimeBaseEntity;
+
+@Getter
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class PostEntity extends TimeBaseEntity {
+
+    @Setter
+    private Long id;
+    private final String userId;
+    private final String categoryCode;
+    private final String title;
+    private final String content;
+    private final Long likeCount;
+
+    public Post toDomain() {
+        return new Post(id, userId, categoryCode, title, content, likeCount);
+    }
+}
+
+

--- a/src/main/java/org/example/workingmoney/repository/post/PostMapper.java
+++ b/src/main/java/org/example/workingmoney/repository/post/PostMapper.java
@@ -1,0 +1,18 @@
+package org.example.workingmoney.repository.post;
+
+import java.util.Optional;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PostMapper {
+
+    void insert(PostEntity postEntity);
+
+    void update(PostEntity postEntity);
+
+    void deleteById(Long id);
+
+    Optional<PostEntity> findById(Long id);
+}
+
+

--- a/src/main/java/org/example/workingmoney/repository/post/PostRepository.java
+++ b/src/main/java/org/example/workingmoney/repository/post/PostRepository.java
@@ -1,0 +1,35 @@
+package org.example.workingmoney.repository.post;
+
+import lombok.RequiredArgsConstructor;
+import org.example.workingmoney.domain.entity.Post;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepository {
+
+    private final PostMapper mapper;
+
+    public Post create(String userId, String categoryCode, String title, String content) {
+        PostEntity entity = new PostEntity(userId, categoryCode, title, content, 0L);
+        mapper.insert(entity);
+        return entity.toDomain();
+    }
+
+    public Optional<Post> findById(Long id) {
+        return mapper.findById(id).map(PostEntity::toDomain);
+    }
+
+    public Post update(Long id, String userId, String categoryCode, String title, String content) {
+        PostEntity entity = new PostEntity(userId, categoryCode, title, content, 0L);
+        entity.setId(id);
+        mapper.update(entity);
+        return findById(id).orElseThrow();
+    }
+
+    public void deleteById(Long id) {
+        mapper.deleteById(id);
+    }
+}

--- a/src/main/java/org/example/workingmoney/service/post/PostService.java
+++ b/src/main/java/org/example/workingmoney/service/post/PostService.java
@@ -1,0 +1,59 @@
+package org.example.workingmoney.service.post;
+
+import lombok.RequiredArgsConstructor;
+import org.example.workingmoney.domain.entity.Post;
+import org.example.workingmoney.repository.post.PostRepository;
+import org.example.workingmoney.service.user.UserService;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserService userService;
+
+    @Transactional
+    public Post create(String userId, String categoryCode, String title, String content) {
+        return postRepository.create(userId, categoryCode, title, content);
+    }
+
+    @Transactional
+    public Post update(Long id, String categoryCode, String title, String content) {
+        Post existing = postRepository.findById(id).orElseThrow();
+
+        String requesterUserId = getAuthenticatedUserId();
+
+        if (!existing.getUserId().equals(requesterUserId)) {
+            throw new IllegalArgumentException("본인 게시글만 수정할 수 있습니다.");
+        }
+
+        return postRepository.update(id, requesterUserId, categoryCode, title, content);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        String authenticatedUserId = getAuthenticatedUserId();
+        Post existing = postRepository.findById(id).orElseThrow();
+        if (!existing.getUserId().equals(authenticatedUserId)) {
+            throw new IllegalArgumentException("본인 게시글만 삭제할 수 있습니다.");
+        }
+
+        postRepository.deleteById(id);
+    }
+
+    private String getAuthenticatedUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            throw new IllegalArgumentException("");
+        }
+
+        return authentication.getName();
+    }
+}

--- a/src/main/java/org/example/workingmoney/ui/controller/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/workingmoney/ui/controller/common/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.example.workingmoney.service.common.exception.InvalidFormatException;
 import org.example.workingmoney.service.common.exception.UnknownException;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -54,6 +55,12 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public Response<Void> handleNoResourceFoundException(Exception exception) {
         return Response.error(new IllegalArgumentException(exception.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response<Void> handleHttpMessageNotReadable(HttpMessageNotReadableException exception) {
+        return Response.error(new InvalidFormatException(exception.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/example/workingmoney/ui/controller/post/PostController.java
+++ b/src/main/java/org/example/workingmoney/ui/controller/post/PostController.java
@@ -1,0 +1,41 @@
+package org.example.workingmoney.ui.controller.post;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.workingmoney.domain.entity.Post;
+import org.example.workingmoney.domain.entity.PostCategory;
+import org.example.workingmoney.service.post.PostService;
+import org.example.workingmoney.ui.controller.common.Response;
+import org.example.workingmoney.ui.dto.request.post.CreatePostRequestDto;
+import org.example.workingmoney.ui.dto.request.post.UpdatePostRequestDto;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public Response<Post> create(@RequestBody @Valid CreatePostRequestDto dto) {
+        PostCategory category = dto.category();
+        Post post = postService.create(dto.userId(), category.getCode(), dto.title(), dto.content());
+        return Response.ok(post);
+    }
+
+    @PutMapping
+    public Response<Post> update(@RequestBody @Valid UpdatePostRequestDto dto) {
+        PostCategory category = dto.category();
+        Post post = postService.update(dto.id(), category.getCode(), dto.title(), dto.content());
+        return Response.ok(post);
+    }
+
+    @DeleteMapping("/{id}")
+    public Response<Void> delete(@PathVariable Long id) {
+        postService.delete(id);
+        return Response.ok(null);
+    }
+}
+
+

--- a/src/main/java/org/example/workingmoney/ui/dto/request/post/CreatePostRequestDto.java
+++ b/src/main/java/org/example/workingmoney/ui/dto/request/post/CreatePostRequestDto.java
@@ -1,0 +1,15 @@
+package org.example.workingmoney.ui.dto.request.post;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.workingmoney.domain.entity.PostCategory;
+
+public record CreatePostRequestDto(
+        @NotNull String userId,
+        @NotNull PostCategory category,
+        @NotBlank String title,
+        @NotBlank String content
+) {}
+
+
+

--- a/src/main/java/org/example/workingmoney/ui/dto/request/post/UpdatePostRequestDto.java
+++ b/src/main/java/org/example/workingmoney/ui/dto/request/post/UpdatePostRequestDto.java
@@ -1,0 +1,15 @@
+package org.example.workingmoney.ui.dto.request.post;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.workingmoney.domain.entity.PostCategory;
+
+public record UpdatePostRequestDto(
+        @NotNull Long id,
+        @NotNull PostCategory category,
+        @NotBlank String title,
+        @NotBlank String content
+) {}
+
+
+

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.example.workingmoney.repository.post.PostMapper">
+
+  <insert id="insert" parameterType="org.example.workingmoney.repository.post.PostEntity"
+    useGeneratedKeys="true" keyProperty="id" keyColumn="id">
+    insert into post (user_id, category_code, title, content, like_count, created_at, updated_at)
+    values (#{userId}, #{categoryCode}, #{title}, #{content}, #{likeCount}, now(), now())
+  </insert>
+
+  <update id="update" parameterType="org.example.workingmoney.repository.post.PostEntity">
+    update post
+    set category_code = #{categoryCode},
+        title = #{title},
+        content = #{content},
+        updated_at = now()
+    where id = #{id}
+  </update>
+
+  <delete id="deleteById">
+    delete from post
+    where id = #{id}
+  </delete>
+
+  <select id="findById" resultType="org.example.workingmoney.repository.post.PostEntity">
+    select id, user_id, category_code, title, content, like_count, created_at, updated_at
+    from post
+    where id = #{id}
+  </select>
+
+</mapper>
+
+

--- a/src/test/java/org/example/workingmoney/repository/post/PostRepositoryTest.java
+++ b/src/test/java/org/example/workingmoney/repository/post/PostRepositoryTest.java
@@ -1,0 +1,87 @@
+package org.example.workingmoney.repository.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.example.workingmoney.domain.entity.Post;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class PostRepositoryTest {
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Test
+    void post_저장시_id_자동_생성_및_조회_테스트() {
+
+        // given
+        String userId = "test@email.com";
+        String categoryCode = "crypto";
+        String title = "hello";
+        String content = "world";
+
+        // when
+        Post created = postRepository.create(userId, categoryCode, title, content);
+
+        // then
+        assertNotNull(created.getId());
+        Post found = postRepository.findById(created.getId()).orElseThrow();
+        assertThat(found.getId()).isEqualTo(created.getId());
+        assertThat(found.getUserId()).isEqualTo(userId);
+        assertThat(found.getCategoryCode()).isEqualTo(categoryCode);
+        assertThat(found.getTitle()).isEqualTo(title);
+        assertThat(found.getContent()).isEqualTo(content);
+        assertThat(found.getLikeCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void post_업데이트_테스트() throws InterruptedException {
+
+        // given
+        String userId = "test@email.com";
+        String categoryCode = "crypto";
+        String title = "title1";
+        String content = "content1";
+        Post created = postRepository.create(userId, categoryCode, title, content);
+        Long id = created.getId();
+
+        // when
+        String newCategory = "american stock";
+        String newTitle = "title2";
+        String newContent = "content2";
+        Post updated = postRepository.update(id, userId, newCategory, newTitle, newContent);
+
+        // then
+        assertThat(updated.getId()).isEqualTo(id);
+        assertThat(updated.getUserId()).isEqualTo(userId);
+        assertThat(updated.getCategoryCode()).isEqualTo(newCategory);
+        assertThat(updated.getTitle()).isEqualTo(newTitle);
+        assertThat(updated.getContent()).isEqualTo(newContent);
+        assertThat(updated.getLikeCount()).isEqualTo(created.getLikeCount());
+    }
+
+    @Test
+    void post_삭제_테스트() {
+
+        // given
+        String userId = "test@email.com";
+        String categoryCode = "FREE";
+        String title = "to be deleted";
+        String content = "bye";
+        Post created = postRepository.create(userId, categoryCode, title, content);
+        Long id = created.getId();
+
+        // when
+        postRepository.deleteById(id);
+
+        // then
+        assertTrue(postRepository.findById(id).isEmpty());
+    }
+}
+
+

--- a/src/test/java/org/example/workingmoney/service/post/PostServiceTest.java
+++ b/src/test/java/org/example/workingmoney/service/post/PostServiceTest.java
@@ -1,0 +1,151 @@
+package org.example.workingmoney.service.post;
+
+import org.example.workingmoney.domain.entity.Post;
+import org.example.workingmoney.repository.post.PostRepository;
+import org.example.workingmoney.service.user.UserService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @InjectMocks
+    private PostService postService;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Test
+    void post_생성_테스트() {
+        // given
+        String userId = "test@email.com";
+        String categoryCode = "crypto";
+        String title = "hello";
+        String content = "world";
+        Post expected = new Post(10L, userId, categoryCode, title, content, 0L);
+
+        when(postRepository.create(userId, categoryCode, title, content)).thenReturn(expected);
+
+        // when
+        Post actual = postService.create(userId, categoryCode, title, content);
+
+        // then
+        assertSame(expected, actual);
+        verify(postRepository, times(1)).create(userId, categoryCode, title, content);
+        verifyNoMoreInteractions(postRepository);
+    }
+
+    @Test
+    void post_업데이트_테스트() {
+        // given
+        Long id = 20L;
+        String userId = "test@email.com";
+        String categoryCode = "stock";
+        String title = "title2";
+        String content = "content2";
+        Post updated = new Post(id, userId, categoryCode, title, content, 3L);
+        when(postRepository.findById(id))
+                .thenReturn(java.util.Optional.of(new Post(id, userId, categoryCode, "title1", "content1", 3L)));
+        when(postRepository.update(id, userId, categoryCode, title, content)).thenReturn(updated);
+        setAuthenticatedUser(userId);
+
+        // when
+        Post actual = postService.update(id, categoryCode, title, content);
+
+        // then
+        assertSame(updated, actual);
+        verify(postRepository, times(1)).findById(id);
+        verify(postRepository, times(1)).update(id, userId, categoryCode, title, content);
+        verifyNoMoreInteractions(postRepository);
+    }
+
+    @Test
+    void post_삭제_테스트() {
+        // given
+        Long id = 30L;
+        String userId = "test@email.com";
+        when(postRepository.findById(id))
+                .thenReturn(java.util.Optional.of(new Post(id, userId, "crypto", "t", "c", 0L)));
+        setAuthenticatedUser(userId);
+
+        // when
+        postService.delete(id);
+
+        // then
+        verify(postRepository, times(1)).deleteById(id);
+        verifyNoMoreInteractions(postRepository);
+    }
+
+    @Test
+    void post_업데이트_권한_에러_테스트() {
+        // given
+        Long id = 40L;
+        String ownerUserId = "owner@email.com";
+        String otherUserId = "other@email.com";
+        String categoryCode = "stock";
+        String title = "newTitle";
+        String content = "newContent";
+        when(postRepository.findById(id))
+                .thenReturn(java.util.Optional.of(new Post(id, ownerUserId, categoryCode, "old", "old", 0L)));
+        setAuthenticatedUser(otherUserId);
+
+        // when & then
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> postService.update(id, categoryCode, title, content));
+        assertEquals("본인 게시글만 수정할 수 있습니다.", ex.getMessage());
+        verify(postRepository, times(1)).findById(id);
+        verify(postRepository, never()).update(anyLong(), anyString(), anyString(), anyString(), anyString());
+        verifyNoMoreInteractions(postRepository);
+    }
+
+    @Test
+    void post_삭제_권한_에러_테스트() {
+        // given
+        Long id = 50L;
+        String ownerUserId = "owner@email.com";
+        String otherUserId = "other@email.com";
+        when(postRepository.findById(id))
+                .thenReturn(java.util.Optional.of(new Post(id, ownerUserId, "crypto", "t", "c", 0L)));
+        setAuthenticatedUser(otherUserId);
+
+        // when & then
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> postService.delete(id));
+        assertEquals("본인 게시글만 삭제할 수 있습니다.", ex.getMessage());
+        verify(postRepository, times(1)).findById(id);
+        verify(postRepository, never()).deleteById(anyLong());
+        verifyNoMoreInteractions(postRepository);
+    }
+
+    private void setAuthenticatedUser(String userId) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                userId,
+                null,
+                java.util.Collections.emptyList()
+        );
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+}
+
+

--- a/src/test/java/org/example/workingmoney/ui/controller/post/PostControllerTest.java
+++ b/src/test/java/org/example/workingmoney/ui/controller/post/PostControllerTest.java
@@ -1,0 +1,174 @@
+package org.example.workingmoney.ui.controller.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.workingmoney.service.post.PostService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PostController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PostService postService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 게시글_생성_성공_테스트() throws Exception {
+        var json = """
+            {
+              "userId": "test@email.com",
+              "category": "korean_stocks",
+              "title": "제목",
+              "content": "내용"
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.message").value("ok"));
+
+        verify(postService, times(1))
+                .create("test@email.com", "korean_stocks", "제목", "내용");
+    }
+
+    @Test
+    void 게시글_생성_유효성_검사_실패_테스트() throws Exception {
+        var json = """
+            {
+              "userId": 1,
+              "category": "korean_stocks",
+              "title": "",
+              "content": "내용"
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+
+        verify(postService, never())
+                .create(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void 게시글_수정_성공_테스트() throws Exception {
+        var json = """
+            {
+              "id": 10,
+              "userId": 1,
+              "category": "korean_stocks",
+              "title": "새 제목",
+              "content": "내용"
+            }
+            """;
+
+        mockMvc.perform(put("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.message").value("ok"));
+
+        verify(postService, times(1))
+                .update(10L, "korean_stocks", "새 제목", "내용");
+    }
+
+    @Test
+    void 게시글_수정_유효성_검사_실패_테스트() throws Exception {
+        var json = """
+            {
+              "id": 10,
+              "category": "korean_stocks",
+              "title": "",
+              "content": "내용"
+            }
+            """;
+
+        mockMvc.perform(put("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+
+        verify(postService, never())
+                .update(anyLong(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void 게시글_생성_category_잘못된_값_실패_테스트() throws Exception {
+        var json = """
+            {
+              "userId": 1,
+              "category": "invalid_category",
+              "title": "제목",
+              "content": "내용"
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+
+        verify(postService, never())
+                .create(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void 게시글_수정_category_잘못된_값_실패_테스트() throws Exception {
+        var json = """
+            {
+              "id": 10,
+              "userId": 1,
+              "category": "invalid_category",
+              "title": "새 제목",
+              "content": "내용"
+            }
+            """;
+
+        mockMvc.perform(put("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+
+        verify(postService, never())
+                .update(anyLong(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void 게시글_삭제_성공_테스트() throws Exception {
+        mockMvc.perform(delete("/api/v1/posts/{id}", 10L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.message").value("ok"));
+
+        verify(postService, times(1)).delete(10L);
+    }
+}
+
+


### PR DESCRIPTION
> 관련 이슈: https://github.com/f-lab-edu/working-money/issues/10

## 구현 내용
- 게시글 create, update, delete 구현

## 참고
- 저번에 말씀해주신 것처럼 Repository Layer에서 사용하기위한 정의한 DTO를 Domain Layer에서 사용하지 않기위해 어댑터 패턴 활용해봤습니다. PostMapper 에서 마이바티스 쿼리 작업 진행하고, PostRepository 에서 PostMapper 를 사용하도록해 Domain Layer의 Entity를 반환하도록 했습니다.