### PR TITLE
Feat/#12 게시글 read 구현

### DIFF
--- a/src/main/java/org/example/workingmoney/domain/entity/Comment.java
+++ b/src/main/java/org/example/workingmoney/domain/entity/Comment.java
@@ -1,0 +1,14 @@
+package org.example.workingmoney.domain.entity;
+
+import lombok.NonNull;
+
+public record Comment(
+        @NonNull Long id,
+        @NonNull Long postId,
+        @NonNull String userId,
+        @NonNull String content) {
+
+}
+
+
+

--- a/src/main/java/org/example/workingmoney/domain/entity/CursorSlice.java
+++ b/src/main/java/org/example/workingmoney/domain/entity/CursorSlice.java
@@ -1,0 +1,22 @@
+package org.example.workingmoney.domain.entity;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record CursorSlice<T>(
+        List<T> content,
+        Long nextCursor,
+        boolean hasNext
+) {
+    public static <T> CursorSlice<T> createCursorSlice(
+            List<T> items,
+            int requestedSize,
+            Function<T, Long> idExtractor
+    ) {
+        boolean hasNext = items.size() > requestedSize;
+        List<T> content = hasNext ? items.subList(0, requestedSize) : items;
+        Long nextCursor = hasNext && !content.isEmpty() ? idExtractor.apply(content.get(content.size() - 1)) : null;
+
+        return new CursorSlice<>(content, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/org/example/workingmoney/domain/entity/Post.java
+++ b/src/main/java/org/example/workingmoney/domain/entity/Post.java
@@ -1,30 +1,16 @@
 package org.example.workingmoney.domain.entity;
 
-import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public class Post {
+public record Post(
+        @NonNull Long id,
+        @NonNull String userId,
+        @NonNull String categoryCode,
+        @NonNull String title,
+        @NonNull String content,
+        @NonNull Long likeCount
+) {
 
-    @NonNull
-    private final Long id;
-
-    @NonNull
-    private final String userId;
-
-    @NonNull
-    private final String categoryCode;
-
-    @NonNull
-    private final String title;
-
-    @NonNull
-    private final String content;
-
-    @NonNull
-    private final Long likeCount;
 }
 
 

--- a/src/main/java/org/example/workingmoney/domain/entity/PostCategory.java
+++ b/src/main/java/org/example/workingmoney/domain/entity/PostCategory.java
@@ -23,6 +23,11 @@ public enum PostCategory {
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static PostCategory from(String value) {
+
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        
         return Arrays.stream(values())
                 .filter(c -> c.code.equals(value))
                 .findFirst()

--- a/src/main/java/org/example/workingmoney/domain/entity/PostCategory.java
+++ b/src/main/java/org/example/workingmoney/domain/entity/PostCategory.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.Arrays;
+import java.util.Optional;
+import javax.swing.text.html.Option;
 
 public enum PostCategory {
     KOREAN_STOCKS("korean_stocks"),
@@ -22,16 +24,11 @@ public enum PostCategory {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static PostCategory from(String value) {
+    public static Optional<PostCategory> from(String value) {
 
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        
         return Arrays.stream(values())
                 .filter(c -> c.code.equals(value))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid category: " + value));
+                .findFirst();
     }
 }
 

--- a/src/main/java/org/example/workingmoney/repository/post/CommentEntity.java
+++ b/src/main/java/org/example/workingmoney/repository/post/CommentEntity.java
@@ -1,0 +1,24 @@
+package org.example.workingmoney.repository.post;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.example.workingmoney.domain.entity.Comment;
+import org.example.workingmoney.repository.common.TimeBaseEntity;
+
+@Getter
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class CommentEntity extends TimeBaseEntity {
+
+    private final long id;
+    private final long postId;
+    private final String userId;
+    private final String content;
+
+    public Comment toDomain() {
+        return new Comment(id, postId, userId, content);
+    }
+}

--- a/src/main/java/org/example/workingmoney/repository/post/CommentMapper.java
+++ b/src/main/java/org/example/workingmoney/repository/post/CommentMapper.java
@@ -1,0 +1,13 @@
+package org.example.workingmoney.repository.post;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface CommentMapper {
+
+    List<CommentEntity> findByPostId(Long postId);
+}
+
+

--- a/src/main/java/org/example/workingmoney/repository/post/CommentRepository.java
+++ b/src/main/java/org/example/workingmoney/repository/post/CommentRepository.java
@@ -1,0 +1,25 @@
+package org.example.workingmoney.repository.post;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.example.workingmoney.domain.entity.Comment;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepository {
+
+    private final CommentMapper mapper;
+
+    public List<Comment> findByPostId(@NonNull Long postId) {
+
+        return mapper.findByPostId(postId).stream().map(CommentEntity::toDomain).toList();
+    }
+}
+
+

--- a/src/main/java/org/example/workingmoney/repository/post/PostEntity.java
+++ b/src/main/java/org/example/workingmoney/repository/post/PostEntity.java
@@ -6,7 +6,10 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.example.workingmoney.domain.entity.Post;
+import org.example.workingmoney.domain.entity.Comment;
 import org.example.workingmoney.repository.common.TimeBaseEntity;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(force = true)
@@ -24,6 +27,8 @@ public class PostEntity extends TimeBaseEntity {
     @Setter
     private String content;
     private final Long likeCount;
+    @Setter
+    private List<Comment> comments;
 
     public PostEntity(
             String userId,

--- a/src/main/java/org/example/workingmoney/repository/post/PostMapper.java
+++ b/src/main/java/org/example/workingmoney/repository/post/PostMapper.java
@@ -13,7 +13,7 @@ public interface PostMapper {
 
     void deleteById(Long id);
 
-    Optional<PostEntity> findById(Long id);
+    Optional<PostEntity> getById(Long id);
 
     List<PostEntity> findPosts(String categoryCode, Long cursor, Integer size);
 }

--- a/src/main/java/org/example/workingmoney/repository/post/PostMapper.java
+++ b/src/main/java/org/example/workingmoney/repository/post/PostMapper.java
@@ -1,5 +1,6 @@
 package org.example.workingmoney.repository.post;
 
+import java.util.List;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -13,6 +14,8 @@ public interface PostMapper {
     void deleteById(Long id);
 
     Optional<PostEntity> findById(Long id);
+
+    List<PostEntity> findPosts(String categoryCode, Long cursor, Integer size);
 }
 
 

--- a/src/main/java/org/example/workingmoney/repository/post/PostRepository.java
+++ b/src/main/java/org/example/workingmoney/repository/post/PostRepository.java
@@ -19,17 +19,17 @@ public class PostRepository {
         return entity.toDomain();
     }
 
-    public Optional<Post> findById(Long id) {
-        return mapper.findById(id).map(PostEntity::toDomain);
+    public Post getById(Long id) {
+        return mapper.getById(id).map(PostEntity::toDomain).orElseThrow();
     }
 
     public Post update(Long id, String userId, String categoryCode, String title, String content) {
-        PostEntity entity = mapper.findById(id).orElseThrow();
+        PostEntity entity = mapper.getById(id).orElseThrow();
         entity.setCategoryCode(categoryCode);
         entity.setTitle(title);
         entity.setContent(content);
         mapper.update(entity);
-        return findById(id).orElseThrow();
+        return getById(id);
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/org/example/workingmoney/repository/post/PostRepository.java
+++ b/src/main/java/org/example/workingmoney/repository/post/PostRepository.java
@@ -1,10 +1,10 @@
 package org.example.workingmoney.repository.post;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.ibatis.javassist.NotFoundException;
 import org.example.workingmoney.domain.entity.Post;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -34,5 +34,12 @@ public class PostRepository {
 
     public void deleteById(Long id) {
         mapper.deleteById(id);
+    }
+
+    public List<Post> findPosts(String categoryCode, Long cursor, Integer size) {
+        return mapper.findPosts(categoryCode, cursor, size)
+                .stream()
+                .map(PostEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/org/example/workingmoney/service/post/PostService.java
+++ b/src/main/java/org/example/workingmoney/service/post/PostService.java
@@ -3,6 +3,8 @@ package org.example.workingmoney.service.post;
 import lombok.RequiredArgsConstructor;
 import org.example.workingmoney.domain.entity.Post;
 import org.example.workingmoney.repository.post.PostRepository;
+import org.example.workingmoney.repository.post.CommentRepository;
+import org.example.workingmoney.domain.entity.Comment;
 import org.example.workingmoney.domain.entity.CursorSlice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,7 @@ import java.util.List;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public Post create(String userId, String categoryCode, String title, String content) {
@@ -41,14 +44,24 @@ public class PostService {
     }
 
     @Transactional
-    public CursorSlice<Post> getPostsWithCursor(String categoryCode, Long cursor, int size) {
+    public CursorSlice<Post> findPostsWithCursor(String categoryCode, Long cursor, int size) {
         List<Post> posts = postRepository.findPosts(categoryCode, cursor, size + 1);
-        return CursorSlice.createCursorSlice(posts, size, Post::getId);
+        return CursorSlice.createCursorSlice(posts, size, Post::id);
+    }
+
+    @Transactional
+    public Post getPostById(Long postId) {
+        return postRepository.getById(postId);
+    }
+
+    @Transactional
+    public List<Comment> getCommentsByPostId(Long postId) {
+        return commentRepository.findByPostId(postId);
     }
 
     private void validateOwner(Long postId, String userId) {
-        Post existingPost = postRepository.findById(postId).orElseThrow();
-        if (!existingPost.getUserId().equals(userId)) {
+        Post existingPost = postRepository.getById(postId);
+        if (!existingPost.userId().equals(userId)) {
             throw new IllegalArgumentException("사용자가 작성한 글이 아닙니다.");
         }
     }

--- a/src/main/java/org/example/workingmoney/service/post/PostService.java
+++ b/src/main/java/org/example/workingmoney/service/post/PostService.java
@@ -3,8 +3,11 @@ package org.example.workingmoney.service.post;
 import lombok.RequiredArgsConstructor;
 import org.example.workingmoney.domain.entity.Post;
 import org.example.workingmoney.repository.post.PostRepository;
+import org.example.workingmoney.domain.entity.CursorSlice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -35,6 +38,12 @@ public class PostService {
         validateOwner(id, userId);
 
         postRepository.deleteById(id);
+    }
+
+    @Transactional
+    public CursorSlice<Post> getPostsWithCursor(String categoryCode, Long cursor, int size) {
+        List<Post> posts = postRepository.findPosts(categoryCode, cursor, size + 1);
+        return CursorSlice.createCursorSlice(posts, size, Post::getId);
     }
 
     private void validateOwner(Long postId, String userId) {

--- a/src/main/java/org/example/workingmoney/ui/controller/post/PostController.java
+++ b/src/main/java/org/example/workingmoney/ui/controller/post/PostController.java
@@ -5,10 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.example.workingmoney.domain.entity.Post;
 import org.example.workingmoney.domain.entity.PostCategory;
 import org.example.workingmoney.service.common.SecurityProvider;
+import org.example.workingmoney.domain.entity.CursorSlice;
 import org.example.workingmoney.service.post.PostService;
 import org.example.workingmoney.ui.controller.common.Response;
 import org.example.workingmoney.ui.dto.request.post.CreatePostRequestDto;
 import org.example.workingmoney.ui.dto.request.post.UpdatePostRequestDto;
+import org.example.workingmoney.ui.dto.response.post.PostCursorResponseDto;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -50,6 +52,20 @@ public class PostController {
 
         return Response.ok(null);
     }
+
+    @GetMapping
+    public Response<PostCursorResponseDto> getPosts(
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") Integer size) {
+        PostCategory postCategory = PostCategory.from(category);
+        CursorSlice<Post> slice = postService.getPostsWithCursor(
+                postCategory != null ? postCategory.getCode() : null,
+                cursor,
+                size
+        );
+        PostCursorResponseDto response = PostCursorResponseDto.fromSlice(slice);
+
+        return Response.ok(response);
+    }
 }
-
-

--- a/src/main/java/org/example/workingmoney/ui/controller/post/PostController.java
+++ b/src/main/java/org/example/workingmoney/ui/controller/post/PostController.java
@@ -72,12 +72,10 @@ public class PostController {
         return Response.ok(response);
     }
 
-    @GetMapping
+    @GetMapping("/detail")
     public Response<PostDetailResponseDTO> getPostDetail(
             @RequestParam(required = true) Long postId
     ) {
-        postService.getPostById(postId);
-        postService.getCommentsByPostId(postId);
 
         return Response.ok(new PostDetailResponseDTO(
                 postService.getPostById(postId), postService.getCommentsByPostId(postId)));

--- a/src/main/java/org/example/workingmoney/ui/dto/request/post/PostCursorRequestDto.java
+++ b/src/main/java/org/example/workingmoney/ui/dto/request/post/PostCursorRequestDto.java
@@ -1,0 +1,20 @@
+package org.example.workingmoney.ui.dto.request.post;
+
+import org.example.workingmoney.domain.entity.PostCategory;
+
+public record PostCursorRequestDto(
+        PostCategory category, 
+        Long cursor,            // 마지막 게시글 ID (첫 요청 시 null)
+        Integer size
+) {
+    public PostCursorRequestDto {
+        if (size == null || size <= 0) {
+            size = 20;
+        }
+    }
+
+    public String getCategoryCode() {
+        return category != null ? category.getCode() : null;
+    }
+}
+

--- a/src/main/java/org/example/workingmoney/ui/dto/response/post/PostCursorResponseDto.java
+++ b/src/main/java/org/example/workingmoney/ui/dto/response/post/PostCursorResponseDto.java
@@ -1,0 +1,18 @@
+package org.example.workingmoney.ui.dto.response.post;
+
+import org.example.workingmoney.domain.entity.CursorSlice;
+import org.example.workingmoney.domain.entity.Post;
+
+import java.util.List;
+
+public record PostCursorResponseDto(
+        List<Post> content,
+        Long nextCursor,
+        boolean hasNext
+) {
+
+    public static PostCursorResponseDto fromSlice(CursorSlice<Post> slice) {
+        return new PostCursorResponseDto(slice.content(), slice.nextCursor(), slice.hasNext());
+    }
+}
+

--- a/src/main/java/org/example/workingmoney/ui/dto/response/post/PostCursorWithCommentsResponseDto.java
+++ b/src/main/java/org/example/workingmoney/ui/dto/response/post/PostCursorWithCommentsResponseDto.java
@@ -1,0 +1,28 @@
+package org.example.workingmoney.ui.dto.response.post;
+
+import org.example.workingmoney.domain.entity.CursorSlice;
+import org.example.workingmoney.domain.entity.Post;
+import org.example.workingmoney.domain.entity.Comment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record PostCursorWithCommentsResponseDto(
+        List<PostWithCommentsDto> content,
+        Long nextCursor,
+        boolean hasNext
+) {
+
+    public static PostCursorWithCommentsResponseDto from(
+            CursorSlice<Post> slice,
+            Map<Long, List<Comment>> commentsByPostId
+    ) {
+        List<PostWithCommentsDto> content = slice.content().stream()
+                .map(p -> new PostWithCommentsDto(p, commentsByPostId.getOrDefault(p.id(), List.of())))
+                .collect(Collectors.toList());
+        return new PostCursorWithCommentsResponseDto(content, slice.nextCursor(), slice.hasNext());
+    }
+}
+
+

--- a/src/main/java/org/example/workingmoney/ui/dto/response/post/PostDetailResponseDTO.java
+++ b/src/main/java/org/example/workingmoney/ui/dto/response/post/PostDetailResponseDTO.java
@@ -1,0 +1,11 @@
+package org.example.workingmoney.ui.dto.response.post;
+
+import java.util.List;
+import org.example.workingmoney.domain.entity.Comment;
+import org.example.workingmoney.domain.entity.Post;
+
+public record PostDetailResponseDTO(
+        Post post,
+        List<Comment> comments) {
+
+}

--- a/src/main/java/org/example/workingmoney/ui/dto/response/post/PostWithCommentsDto.java
+++ b/src/main/java/org/example/workingmoney/ui/dto/response/post/PostWithCommentsDto.java
@@ -1,0 +1,13 @@
+package org.example.workingmoney.ui.dto.response.post;
+
+import org.example.workingmoney.domain.entity.Comment;
+import org.example.workingmoney.domain.entity.Post;
+
+import java.util.List;
+
+public record PostWithCommentsDto(
+        Post post,
+        List<Comment> comments
+) {}
+
+

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.example.workingmoney.repository.post.CommentMapper">
+
+  <select id="findByPostId" resultType="org.example.workingmoney.repository.post.CommentEntity">
+    select id, post_id, user_id, content, created_at, updated_at
+    from comment
+    where post_id = #{postId}
+    order by id asc
+  </select>
+
+</mapper>
+
+

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -24,9 +24,38 @@
   </delete>
 
   <select id="findById" resultType="org.example.workingmoney.repository.post.PostEntity">
-    select id, user_id, category_code, title, content, like_count, created_at, updated_at
-    from post
-    where id = #{id}
+    select p.id, p.user_id, p.category_code, p.title, p.content,
+           coalesce(pl.like_count, 0) as like_count,
+           p.created_at, p.updated_at
+    from post p
+    left join (
+      select post_id, count(*) as like_count
+      from post_like
+      group by post_id
+    ) pl on pl.post_id = p.id
+    where p.id = #{id}
+  </select>
+
+  <select id="findPosts" resultType="org.example.workingmoney.repository.post.PostEntity">
+    select p.id, p.user_id, p.category_code, p.title, p.content,
+           coalesce(pl.like_count, 0) as like_count,
+           p.created_at, p.updated_at
+    from post p
+    left join (
+      select post_id, count(*) as like_count
+      from post_like
+      group by post_id
+    ) pl on pl.post_id = p.id
+    <where>
+      <if test="categoryCode != null">
+        and p.category_code = #{categoryCode}
+      </if>
+      <if test="cursor != null">
+        and p.id &lt; #{cursor}
+      </if>
+    </where>
+    order by p.id desc
+    limit #{size}
   </select>
 
 </mapper>

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -23,7 +23,7 @@
     where id = #{id}
   </delete>
 
-  <select id="findById" resultType="org.example.workingmoney.repository.post.PostEntity">
+  <select id="getById" resultType="org.example.workingmoney.repository.post.PostEntity">
     select p.id, p.user_id, p.category_code, p.title, p.content,
            coalesce(pl.like_count, 0) as like_count,
            p.created_at, p.updated_at

--- a/src/test/java/org/example/workingmoney/repository/post/CommentRepositoryTest.java
+++ b/src/test/java/org/example/workingmoney/repository/post/CommentRepositoryTest.java
@@ -1,0 +1,63 @@
+package org.example.workingmoney.repository.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.example.workingmoney.domain.entity.Comment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class CommentRepositoryTest {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    Long savedPostId;
+
+    @BeforeEach
+    void setUp() {
+        var post = postRepository.create("cmt-user@example.com", "crypto", "post title", "post content");
+        savedPostId = post.id();
+
+        // 댓글 2건 삽입
+        jdbcTemplate.update(
+                "insert into comment (post_id, user_id, content, created_at, updated_at) values (?, ?, ?, now(), now())",
+                savedPostId, "user1@example.com", "first comment");
+        jdbcTemplate.update(
+                "insert into comment (post_id, user_id, content, created_at, updated_at) values (?, ?, ?, now(), now())",
+                savedPostId, "user2@example.com", "second comment");
+    }
+
+    @Test
+    void postId로_댓글_목록_조회_테스트() {
+        List<Comment> comments = commentRepository.findByPostId(savedPostId);
+
+        assertThat(comments).hasSize(2);
+        assertThat(comments.get(0).postId()).isEqualTo(savedPostId);
+        assertThat(comments.get(1).postId()).isEqualTo(savedPostId);
+        assertThat(comments.get(0).content()).isEqualTo("first comment");
+        assertThat(comments.get(1).content()).isEqualTo("second comment");
+    }
+
+    @Test
+    void 댓글_없는_postId는_빈목록_반환() {
+        Long otherPostId = postRepository.create("other@example.com", "crypto", "title", "content").id();
+
+        List<Comment> comments = commentRepository.findByPostId(otherPostId);
+        assertThat(comments).isEmpty();
+    }
+}
+
+

--- a/src/test/java/org/example/workingmoney/repository/post/PostRepositoryTest.java
+++ b/src/test/java/org/example/workingmoney/repository/post/PostRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.example.workingmoney.domain.entity.Post;
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,7 +31,7 @@ class PostRepositoryTest {
 
         // then
         assertNotNull(created.id());
-        Post found = postRepository.getById(created.id()).orElseThrow();
+        Post found = postRepository.getById(created.id());
         assertThat(found.id()).isEqualTo(created.id());
         assertThat(found.userId()).isEqualTo(userId);
         assertThat(found.categoryCode()).isEqualTo(categoryCode);
@@ -80,7 +81,7 @@ class PostRepositoryTest {
         postRepository.deleteById(id);
 
         // then
-        assertTrue(postRepository.getById(id).isEmpty());
+        assertThrows(NoSuchElementException.class, () -> postRepository.getById(id));
     }
 }
 

--- a/src/test/java/org/example/workingmoney/repository/post/PostRepositoryTest.java
+++ b/src/test/java/org/example/workingmoney/repository/post/PostRepositoryTest.java
@@ -29,14 +29,14 @@ class PostRepositoryTest {
         Post created = postRepository.create(userId, categoryCode, title, content);
 
         // then
-        assertNotNull(created.getId());
-        Post found = postRepository.findById(created.getId()).orElseThrow();
-        assertThat(found.getId()).isEqualTo(created.getId());
-        assertThat(found.getUserId()).isEqualTo(userId);
-        assertThat(found.getCategoryCode()).isEqualTo(categoryCode);
-        assertThat(found.getTitle()).isEqualTo(title);
-        assertThat(found.getContent()).isEqualTo(content);
-        assertThat(found.getLikeCount()).isEqualTo(0L);
+        assertNotNull(created.id());
+        Post found = postRepository.getById(created.id()).orElseThrow();
+        assertThat(found.id()).isEqualTo(created.id());
+        assertThat(found.userId()).isEqualTo(userId);
+        assertThat(found.categoryCode()).isEqualTo(categoryCode);
+        assertThat(found.title()).isEqualTo(title);
+        assertThat(found.content()).isEqualTo(content);
+        assertThat(found.likeCount()).isEqualTo(0L);
     }
 
     @Test
@@ -48,7 +48,7 @@ class PostRepositoryTest {
         String title = "title1";
         String content = "content1";
         Post created = postRepository.create(userId, categoryCode, title, content);
-        Long id = created.getId();
+        Long id = created.id();
 
         // when
         String newCategory = "american stock";
@@ -57,12 +57,12 @@ class PostRepositoryTest {
         Post updated = postRepository.update(id, userId, newCategory, newTitle, newContent);
 
         // then
-        assertThat(updated.getId()).isEqualTo(id);
-        assertThat(updated.getUserId()).isEqualTo(userId);
-        assertThat(updated.getCategoryCode()).isEqualTo(newCategory);
-        assertThat(updated.getTitle()).isEqualTo(newTitle);
-        assertThat(updated.getContent()).isEqualTo(newContent);
-        assertThat(updated.getLikeCount()).isEqualTo(created.getLikeCount());
+        assertThat(updated.id()).isEqualTo(id);
+        assertThat(updated.userId()).isEqualTo(userId);
+        assertThat(updated.categoryCode()).isEqualTo(newCategory);
+        assertThat(updated.title()).isEqualTo(newTitle);
+        assertThat(updated.content()).isEqualTo(newContent);
+        assertThat(updated.likeCount()).isEqualTo(created.likeCount());
     }
 
     @Test
@@ -74,13 +74,13 @@ class PostRepositoryTest {
         String title = "to be deleted";
         String content = "bye";
         Post created = postRepository.create(userId, categoryCode, title, content);
-        Long id = created.getId();
+        Long id = created.id();
 
         // when
         postRepository.deleteById(id);
 
         // then
-        assertTrue(postRepository.findById(id).isEmpty());
+        assertTrue(postRepository.getById(id).isEmpty());
     }
 }
 

--- a/src/test/java/org/example/workingmoney/service/post/PostServiceTest.java
+++ b/src/test/java/org/example/workingmoney/service/post/PostServiceTest.java
@@ -1,6 +1,9 @@
 package org.example.workingmoney.service.post;
 
+import org.example.workingmoney.domain.entity.Comment;
 import org.example.workingmoney.domain.entity.Post;
+import org.example.workingmoney.domain.entity.CursorSlice;
+import org.example.workingmoney.repository.post.CommentRepository;
 import org.example.workingmoney.repository.post.PostRepository;
 import org.example.workingmoney.service.user.UserService;
 import org.junit.jupiter.api.AfterEach;
@@ -16,6 +19,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -28,6 +32,9 @@ class PostServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private CommentRepository commentRepository;
 
     @Test
     void post_생성_테스트() {
@@ -59,7 +66,7 @@ class PostServiceTest {
         String content = "content2";
         Post updated = new Post(id, userId, categoryCode, title, content, 3L);
         when(postRepository.getById(id))
-                .thenReturn(java.util.Optional.of(new Post(id, userId, categoryCode, "title1", "content1", 3L)));
+                .thenReturn(new Post(id, userId, categoryCode, "title1", "content1", 3L));
         when(postRepository.update(id, userId, categoryCode, title, content)).thenReturn(updated);
         setAuthenticatedUser(userId);
 
@@ -79,7 +86,7 @@ class PostServiceTest {
         Long id = 30L;
         String userId = "test@email.com";
         when(postRepository.getById(id))
-                .thenReturn(java.util.Optional.of(new Post(id, userId, "crypto", "t", "c", 0L)));
+                .thenReturn(new Post(id, userId, "crypto", "t", "c", 0L));
         setAuthenticatedUser(userId);
 
         // when
@@ -100,7 +107,7 @@ class PostServiceTest {
         String title = "newTitle";
         String content = "newContent";
         when(postRepository.getById(id))
-                .thenReturn(java.util.Optional.of(new Post(id, ownerUserId, categoryCode, "old", "old", 0L)));
+                .thenReturn(new Post(id, ownerUserId, categoryCode, "old", "old", 0L));
         setAuthenticatedUser(otherUserId);
 
         // when & then
@@ -119,7 +126,7 @@ class PostServiceTest {
         String ownerUserId = "owner@email.com";
         String otherUserId = "other@email.com";
         when(postRepository.getById(id))
-                .thenReturn(java.util.Optional.of(new Post(id, ownerUserId, "crypto", "t", "c", 0L)));
+                .thenReturn(new Post(id, ownerUserId, "crypto", "t", "c", 0L));
         setAuthenticatedUser(otherUserId);
 
         // when & then
@@ -129,6 +136,91 @@ class PostServiceTest {
         verify(postRepository, times(1)).getById(id);
         verify(postRepository, never()).deleteById(anyLong());
         verifyNoMoreInteractions(postRepository);
+    }
+
+    @Test
+    void 커서_기반_목록조회_hasNext_true_테스트() {
+        // given
+        String category = "crypto";
+        Long cursor = 100L;
+        int size = 3;
+        List<Post> fetched = List.of(
+                new Post(99L, "u", category, "t1", "c1", 0L),
+                new Post(98L, "u", category, "t2", "c2", 0L),
+                new Post(97L, "u", category, "t3", "c3", 0L),
+                new Post(96L, "u", category, "t4", "c4", 0L)
+        );
+        when(postRepository.findPosts(eq(category), eq(cursor), eq(size + 1))).thenReturn(fetched);
+
+        // when
+        CursorSlice<Post> slice = postService.findPostsWithCursor(category, cursor, size);
+
+        // then
+        assertEquals(size, slice.content().size());
+        assertTrue(slice.hasNext());
+        assertEquals(97L, slice.nextCursor()); // 마지막 콘텐츠의 id
+        verify(postRepository, times(1)).findPosts(category, cursor, size + 1);
+        verifyNoMoreInteractions(postRepository);
+    }
+
+    @Test
+    void 커서_기반_목록조회_hasNext_false_테스트() {
+        // given
+        String category = null; // 카테고리 미지정 케이스
+        Long cursor = null;
+        int size = 3;
+        List<Post> fetched = List.of(
+                new Post(5L, "u", "free", "t1", "c1", 0L),
+                new Post(4L, "u", "free", "t2", "c2", 0L)
+        );
+        when(postRepository.findPosts(eq(category), eq(cursor), eq(size + 1))).thenReturn(fetched);
+
+        // when
+        CursorSlice<Post> slice = postService.findPostsWithCursor(category, cursor, size);
+
+        // then
+        assertEquals(2, slice.content().size());
+        assertFalse(slice.hasNext());
+        assertNull(slice.nextCursor()); // hasNext=false면 nextCursor=null
+        verify(postRepository, times(1)).findPosts(category, cursor, size + 1);
+        verifyNoMoreInteractions(postRepository);
+    }
+
+    @Test
+    void 단건조회_getPostById_테스트() {
+        // given
+        Long id = 10L;
+        Post expected = new Post(id, "u", "crypto", "t", "c", 0L);
+        when(postRepository.getById(id)).thenReturn(expected);
+
+        // when
+        Post actual = postService.getPostById(id);
+
+        // then
+        assertSame(expected, actual);
+        verify(postRepository, times(1)).getById(id);
+        verifyNoMoreInteractions(postRepository);
+    }
+
+    @Test
+    void 댓글목록조회_getCommentsByPostId_테스트() {
+        // given
+        Long postId = 11L;
+        var comments = java.util.List.of(
+                new Comment(1L, postId, "userA", "c1"),
+                new Comment(2L, postId, "userB", "c2")
+        );
+        when(commentRepository.findByPostId(postId)).thenReturn(comments);
+
+        // when
+        var actual = postService.getCommentsByPostId(postId);
+
+        // then
+        assertEquals(2, actual.size());
+        assertEquals("c1", actual.get(0).content());
+        assertEquals("c2", actual.get(1).content());
+        verify(commentRepository, times(1)).findByPostId(postId);
+        verifyNoMoreInteractions(commentRepository);
     }
 
     private void setAuthenticatedUser(String userId) {

--- a/src/test/java/org/example/workingmoney/service/post/PostServiceTest.java
+++ b/src/test/java/org/example/workingmoney/service/post/PostServiceTest.java
@@ -58,7 +58,7 @@ class PostServiceTest {
         String title = "title2";
         String content = "content2";
         Post updated = new Post(id, userId, categoryCode, title, content, 3L);
-        when(postRepository.findById(id))
+        when(postRepository.getById(id))
                 .thenReturn(java.util.Optional.of(new Post(id, userId, categoryCode, "title1", "content1", 3L)));
         when(postRepository.update(id, userId, categoryCode, title, content)).thenReturn(updated);
         setAuthenticatedUser(userId);
@@ -68,7 +68,7 @@ class PostServiceTest {
 
         // then
         assertSame(updated, actual);
-        verify(postRepository, times(1)).findById(id);
+        verify(postRepository, times(1)).getById(id);
         verify(postRepository, times(1)).update(id, userId, categoryCode, title, content);
         verifyNoMoreInteractions(postRepository);
     }
@@ -78,7 +78,7 @@ class PostServiceTest {
         // given
         Long id = 30L;
         String userId = "test@email.com";
-        when(postRepository.findById(id))
+        when(postRepository.getById(id))
                 .thenReturn(java.util.Optional.of(new Post(id, userId, "crypto", "t", "c", 0L)));
         setAuthenticatedUser(userId);
 
@@ -99,7 +99,7 @@ class PostServiceTest {
         String categoryCode = "stock";
         String title = "newTitle";
         String content = "newContent";
-        when(postRepository.findById(id))
+        when(postRepository.getById(id))
                 .thenReturn(java.util.Optional.of(new Post(id, ownerUserId, categoryCode, "old", "old", 0L)));
         setAuthenticatedUser(otherUserId);
 
@@ -107,7 +107,7 @@ class PostServiceTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> postService.update(id, otherUserId, categoryCode, title, content));
         assertEquals("사용자가 작성한 글이 아닙니다.", ex.getMessage());
-        verify(postRepository, times(1)).findById(id);
+        verify(postRepository, times(1)).getById(id);
         verify(postRepository, never()).update(anyLong(), anyString(), anyString(), anyString(), anyString());
         verifyNoMoreInteractions(postRepository);
     }
@@ -118,7 +118,7 @@ class PostServiceTest {
         Long id = 50L;
         String ownerUserId = "owner@email.com";
         String otherUserId = "other@email.com";
-        when(postRepository.findById(id))
+        when(postRepository.getById(id))
                 .thenReturn(java.util.Optional.of(new Post(id, ownerUserId, "crypto", "t", "c", 0L)));
         setAuthenticatedUser(otherUserId);
 
@@ -126,7 +126,7 @@ class PostServiceTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> postService.delete(id, otherUserId));
         assertEquals("사용자가 작성한 글이 아닙니다.", ex.getMessage());
-        verify(postRepository, times(1)).findById(id);
+        verify(postRepository, times(1)).getById(id);
         verify(postRepository, never()).deleteById(anyLong());
         verifyNoMoreInteractions(postRepository);
     }


### PR DESCRIPTION
## 구현 내용
- 게시글 페이지 네이션 읽기 API 
  - 커서 방식의 페이지네이션 처리
  - 게시판 종류별 필터링 기능 구현(모두, 암호 화폐, 국내 주식, 미국 주식)
- 게시글 상세 API 
  - 게시글과 코멘트 같이 읽어 오는 API

